### PR TITLE
feat: 사용자 삭제 기능 추가

### DIFF
--- a/src/main/java/com/ecc/balancegame/controller/CategoryController.java
+++ b/src/main/java/com/ecc/balancegame/controller/CategoryController.java
@@ -1,0 +1,20 @@
+package com.ecc.balancegame.controller;
+
+import com.ecc.balancegame.domain.Category;
+import com.ecc.balancegame.service.CategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class CategoryController {
+    private final CategoryService categoryService;
+
+    @GetMapping("/api/categories")
+    public List<Category> getCategories(){
+        return categoryService.getAllCategories();
+    }
+}

--- a/src/main/java/com/ecc/balancegame/controller/QuestionController.java
+++ b/src/main/java/com/ecc/balancegame/controller/QuestionController.java
@@ -1,0 +1,23 @@
+package com.ecc.balancegame.controller;
+
+import com.ecc.balancegame.dto.QuestionResponseDto;
+import com.ecc.balancegame.service.QuestionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class QuestionController {
+
+    private final QuestionService questionService;
+
+    @GetMapping("/api/categories/{categoryId}/questions")
+    public List<QuestionResponseDto> getQuestions(@PathVariable Long categoryId){
+        return questionService.getQuestionsByCategory(categoryId);
+    }
+}

--- a/src/main/java/com/ecc/balancegame/controller/UserController.java
+++ b/src/main/java/com/ecc/balancegame/controller/UserController.java
@@ -1,0 +1,21 @@
+package com.ecc.balancegame.controller;
+
+import com.ecc.balancegame.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    @DeleteMapping("/api/choices/reset")
+    public ResponseEntity<Void> resetUserChoices(@RequestParam Long userId) {
+        userService.deleteUser(userId);
+        return ResponseEntity.noContent().build();
+    }
+}
+

--- a/src/main/java/com/ecc/balancegame/domain/Category.java
+++ b/src/main/java/com/ecc/balancegame/domain/Category.java
@@ -13,6 +13,7 @@ public class Category {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, name = "category_id")
     private Long categoryId;
 
     @Column(nullable = false, name = "category_name")

--- a/src/main/java/com/ecc/balancegame/domain/Category.java
+++ b/src/main/java/com/ecc/balancegame/domain/Category.java
@@ -1,0 +1,20 @@
+package com.ecc.balancegame.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long categoryId;
+
+    @Column(nullable = false, name = "category_name")
+    private String categoryName;
+}

--- a/src/main/java/com/ecc/balancegame/domain/Question.java
+++ b/src/main/java/com/ecc/balancegame/domain/Question.java
@@ -1,4 +1,28 @@
 package com.ecc.balancegame.domain;
 
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class Question {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, name = "question_id")
+    private Long questionId;
+
+    @ManyToOne
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @Column(columnDefinition = "TEXT", name = "question_text", nullable = false)
+    private String questionText; // 질문 내용
+
+    @Column(name = "order_index", nullable = false)
+    private Integer orderIndex;
 }

--- a/src/main/java/com/ecc/balancegame/domain/Question.java
+++ b/src/main/java/com/ecc/balancegame/domain/Question.java
@@ -1,0 +1,4 @@
+package com.ecc.balancegame.domain;
+
+public class Question {
+}

--- a/src/main/java/com/ecc/balancegame/domain/SelectChoice.java
+++ b/src/main/java/com/ecc/balancegame/domain/SelectChoice.java
@@ -1,0 +1,29 @@
+package com.ecc.balancegame.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SelectChoice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, name = "choice_id")
+    private Long choiceId;
+
+    @ManyToOne
+    @JoinColumn(name = "question_id", nullable = false)
+    private Question question;
+
+    @Column(nullable = false, name = "choice_number")
+    private Integer choiceNumber;
+
+    @Column(nullable = false, name = "choice_text")
+    private String choiceText;
+}

--- a/src/main/java/com/ecc/balancegame/domain/User.java
+++ b/src/main/java/com/ecc/balancegame/domain/User.java
@@ -1,0 +1,24 @@
+package com.ecc.balancegame.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.stereotype.Service;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, name = "user_id")
+    private Long userId;
+
+    @Column(nullable = false, name = "user_name")
+    private String userName;
+}

--- a/src/main/java/com/ecc/balancegame/dto/ChoiceResponseDto.java
+++ b/src/main/java/com/ecc/balancegame/dto/ChoiceResponseDto.java
@@ -1,0 +1,12 @@
+package com.ecc.balancegame.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChoiceResponseDto {
+    private Long choiceId;
+    private Integer choiceNumber;
+    private String choiceText;
+}

--- a/src/main/java/com/ecc/balancegame/dto/QuestionResponseDto.java
+++ b/src/main/java/com/ecc/balancegame/dto/QuestionResponseDto.java
@@ -1,0 +1,16 @@
+package com.ecc.balancegame.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class QuestionResponseDto {
+    private Long questionId;
+    private String questionText;
+    private Long categoryId;
+    private Integer orderIndex;
+    private List<ChoiceResponseDto> choices;
+}

--- a/src/main/java/com/ecc/balancegame/repository/CategoryRepository.java
+++ b/src/main/java/com/ecc/balancegame/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package com.ecc.balancegame.repository;
+
+import com.ecc.balancegame.domain.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/ecc/balancegame/repository/QuestionRepository.java
+++ b/src/main/java/com/ecc/balancegame/repository/QuestionRepository.java
@@ -1,0 +1,14 @@
+package com.ecc.balancegame.repository;
+
+import com.ecc.balancegame.domain.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+    @Query("SELECT q FROM Question q WHERE q.category.categoryId = :categoryId ORDER BY q.orderIndex ASC")
+    List<Question> findByCategoryIdOrderByOrderIndex(@Param("categoryId") Long categoryId);
+}

--- a/src/main/java/com/ecc/balancegame/repository/SelectChoiceRepository.java
+++ b/src/main/java/com/ecc/balancegame/repository/SelectChoiceRepository.java
@@ -1,0 +1,16 @@
+package com.ecc.balancegame.repository;
+
+import com.ecc.balancegame.domain.Question;
+import com.ecc.balancegame.domain.SelectChoice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface SelectChoiceRepository extends JpaRepository<SelectChoice, Long> {
+    List<SelectChoice> findByQuestion(Question question);
+}
+
+
+

--- a/src/main/java/com/ecc/balancegame/repository/UserRepository.java
+++ b/src/main/java/com/ecc/balancegame/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.ecc.balancegame.repository;
+
+import com.ecc.balancegame.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUserId(Long userId);
+
+}

--- a/src/main/java/com/ecc/balancegame/service/CategoryService.java
+++ b/src/main/java/com/ecc/balancegame/service/CategoryService.java
@@ -1,0 +1,20 @@
+package com.ecc.balancegame.service;
+
+import com.ecc.balancegame.domain.Category;
+import com.ecc.balancegame.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor //생성자 자동 생성
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    // 카테고리 목록 조회
+    public List<Category> getAllCategories() {
+        return categoryRepository.findAll();
+    }
+}

--- a/src/main/java/com/ecc/balancegame/service/CategoryService.java
+++ b/src/main/java/com/ecc/balancegame/service/CategoryService.java
@@ -13,7 +13,6 @@ public class CategoryService {
 
     private final CategoryRepository categoryRepository;
 
-    // 카테고리 목록 조회
     public List<Category> getAllCategories() {
         return categoryRepository.findAll();
     }

--- a/src/main/java/com/ecc/balancegame/service/QuestionService.java
+++ b/src/main/java/com/ecc/balancegame/service/QuestionService.java
@@ -1,0 +1,50 @@
+package com.ecc.balancegame.service;
+
+import com.ecc.balancegame.domain.Question;
+import com.ecc.balancegame.domain.SelectChoice;
+import com.ecc.balancegame.dto.ChoiceResponseDto;
+import com.ecc.balancegame.dto.QuestionResponseDto;
+import com.ecc.balancegame.repository.QuestionRepository;
+import com.ecc.balancegame.repository.SelectChoiceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionService {
+
+    private final QuestionRepository questionRepository;
+
+    private final SelectChoiceRepository selectChoiceRepository;
+
+    @Transactional(readOnly = true)
+    public List<QuestionResponseDto> getQuestionsByCategory(Long categoryId) {
+
+        List<Question> questions = questionRepository.findByCategoryIdOrderByOrderIndex(categoryId);
+
+        return questions.stream().map(question -> {
+
+            List<SelectChoice> choices = selectChoiceRepository.findByQuestion(question);
+
+            return new QuestionResponseDto(
+                    question.getQuestionId(),
+                    question.getQuestionText(),
+                    question.getCategory().getCategoryId(),
+                    question.getOrderIndex(),
+                    choices.stream().map(choice -> new ChoiceResponseDto(
+                            choice.getChoiceId(),
+                            choice.getChoiceNumber(),
+                            choice.getChoiceText()
+                    )).collect(Collectors.toList())
+            );
+        }).collect(Collectors.toList());
+    }
+
+
+
+}

--- a/src/main/java/com/ecc/balancegame/service/UserService.java
+++ b/src/main/java/com/ecc/balancegame/service/UserService.java
@@ -1,0 +1,15 @@
+package com.ecc.balancegame.service;
+
+import com.ecc.balancegame.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    public void deleteUser(Long userId){
+        userRepository.deleteById(userId);
+    }
+}


### PR DESCRIPTION
- 사용자가 게임 종료 전 홈 화면으로 돌아갈 때, 'userId'로 'user' 테이블에서 사용자 정보를 삭제하는 기능 추가

- 변경된 파일:
  - `UserRepository`: `userId`로 사용자 삭제 메서드 구현
  - `UserController`: `/api/choices/reset` 엔드포인트 구현.
  - `UserService`: 사용자 정보 삭제 로직 구현
  - 'User' : 'user' 엔티티 추가, 사용자 정보 관리 도메인 구현

